### PR TITLE
feat(links): add support for `title` in inline links

### DIFF
--- a/lib/inline.js
+++ b/lib/inline.js
@@ -524,10 +524,34 @@ InlineCompiler.prototype = {
     var end = walk.indexOf(")");
     if (end === null)
       return false;
+    var mayHaveTitle = true;
+    var urlEnd = walk.indexOf(" ");
+    if (urlEnd === null || urlEnd > end) {
+      urlEnd = end;
+      mayHaveTitle = false;
+    }
     walk.skip();
-    var href = walk.yieldUntil(end);
+    var href = walk.yieldUntil(urlEnd);
+    var title = walk.lookahead(function() {
+      if (mayHaveTitle) {
+        walk.skipWhitespaces();
+        var quote = walk.matchSome(["\"", "'"]);
+        if (quote !== null) {
+          walk.skip();
+          var titleEnd = walk.indexOf(quote);
+          if (titleEnd !== null && titleEnd < end) {
+            return walk.yieldUntil(titleEnd);
+          }
+        }
+      }
+      return null;
+    });
+    if (mayHaveTitle && title === null) {
+      href += walk.yieldUntil(end);
+    }
+    walk.position = end;
     walk.skip();
-    this.emitLink(text, href);
+    this.emitLink(text, {url: href, title: title});
     return true;
   },
 

--- a/test/InlineCompiler.js
+++ b/test/InlineCompiler.js
@@ -149,6 +149,60 @@ describe('InlineCompiler', function() {
         "<a href=\"https://github.com/inca/rho\">Rho</a> is awesome!");
     });
 
+    it("should process inline links with titles", function() {
+      // Double-quotes title
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho \"Good ol' title!\") is awesome!"),
+        "<a href=\"https://github.com/inca/rho\" title=\"Good ol&#x27; title!\">Rho</a> is awesome!");
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho   \"Good ol' title!\"   ) is awesome!"),
+        "<a href=\"https://github.com/inca/rho\" title=\"Good ol&#x27; title!\">Rho</a> is awesome!");
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho \"Good ol\\\" title!\") is awesome!"),
+        "<a href=\"https://github.com/inca/rho\" title=\"Good ol\\&quot; title!\">Rho</a> is awesome!");
+
+      // Single-quoted title
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho 'Good ol\" title!') is awesome!"),
+        "<a href=\"https://github.com/inca/rho\" title=\"Good ol&quot; title!\">Rho</a> is awesome!");
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho   'Good ol\" title!'   ) is awesome!"),
+        "<a href=\"https://github.com/inca/rho\" title=\"Good ol&quot; title!\">Rho</a> is awesome!");
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho 'Good ol\\' title!') is awesome!"),
+        "<a href=\"https://github.com/inca/rho\" title=\"Good ol\\&#x27; title!\">Rho</a> is awesome!");
+
+      // No ending quote; not a title
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho \"Not a title) is awesome!"),
+        "<a href=\"https://github.com/inca/rho \"Not a title\">Rho</a> is awesome!");
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho 'Not a title) is awesome!"),
+        "<a href=\"https://github.com/inca/rho 'Not a title\">Rho</a> is awesome!");
+
+      // No ending quote before `)`; not a title
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho \"Not a title) is \"awesome\"!"),
+        "<a href=\"https://github.com/inca/rho \"Not a title\">Rho</a> is &ldquo;awesome&rdquo;!");
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho 'Not a title) is 'awesome'!"),
+        "<a href=\"https://github.com/inca/rho 'Not a title\">Rho</a> is 'awesome'!");
+
+      // No quotes before `)`; not a title
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho) \"Not a title\""),
+        "<a href=\"https://github.com/inca/rho\">Rho</a> &ldquo;Not a title&rdquo;");
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho   ) \"Not a title\""),
+        "<a href=\"https://github.com/inca/rho   \">Rho</a> &ldquo;Not a title&rdquo;");
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho) 'Not a title'"),
+        "<a href=\"https://github.com/inca/rho\">Rho</a> 'Not a title'");
+      assert.equal(
+        c.toHtml("[Rho](https://github.com/inca/rho   ) 'Not a title'"),
+        "<a href=\"https://github.com/inca/rho   \">Rho</a> 'Not a title'");
+    });
+
     it("should resolve reference images", function() {
       assert.equal(
         c.toHtml("Me: ![Boris Okunskiy][gravatar]"),


### PR DESCRIPTION
In [markdown syntax](https://daringfireball.net/projects/markdown/syntax#link), inline links may have an optional title specified after the URL surrounded by quotes (e.g. `[foo](/path/to/foo "This is a title")`).
This commit adds support for `title` in inline links.

(Note reference links may also specify a title in a similar fashion, but since Rho uses `resolveLink()` atitle can be explicitly specified by including a `title` property in the returned object.)